### PR TITLE
[MLIR][LLVM] Don't use void return type in MLIR APIs.

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMOps.td
@@ -1514,14 +1514,18 @@ def LLVM_LLVMFuncOp : LLVM_Op<"func", [
     ArrayRef<Type> getArgumentTypes() { return getFunctionType().getParams(); }
 
     /// Returns the result types of this function.
-    ArrayRef<Type> getResultTypes() { return getFunctionType().getReturnTypes(); }
+    ArrayRef<Type> getResultTypes() {
+      if (getFunctionType().getReturnType().isa<LLVM::LLVMVoidType>())
+        return {};
+      return getFunctionType().getReturnTypes();
+    }
 
     /// Returns the callable region, which is the function body. If the function
     /// is external, returns null.
     Region *getCallableRegion();
 
     /// Returns the callable result type, which is the function return type.
-    ArrayRef<Type> getCallableResults() { return getFunctionType().getReturnTypes(); }
+    ArrayRef<Type> getCallableResults() { return getResultTypes(); }
 
   }];
 

--- a/mlir/test/Dialect/LLVMIR/func.mlir
+++ b/mlir/test/Dialect/LLVMIR/func.mlir
@@ -256,8 +256,8 @@ module {
 // -----
 
 module {
-  // expected-error@+1 {{cannot attach result attributes to functions with a void return}}
-  llvm.func @variadic_def() -> (!llvm.void {llvm.noundef})
+  // expected-error@+1 {{void return type should not be passed explicitly}}
+  llvm.func @variadic_def() -> (!llvm.void)
 }
 
 // -----

--- a/mlir/test/Target/LLVMIR/llvmir-types.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir-types.mlir
@@ -5,7 +5,7 @@
 //
 
 // CHECK: declare void @return_void()
-llvm.func @return_void() -> !llvm.void
+llvm.func @return_void()
 // CHECK: declare half @return_half()
 llvm.func @return_half() -> f16
 // CHECK: declare bfloat @return_bfloat()
@@ -28,7 +28,7 @@ llvm.func @return_x86_mmx() -> !llvm.x86_mmx
 //
 
 // CHECK: declare void @f_void_i32(i32)
-llvm.func @f_void_i32(i32) -> !llvm.void
+llvm.func @f_void_i32(i32)
 // CHECK: declare i32 @f_i32_empty()
 llvm.func @f_i32_empty() -> i32
 // CHECK: declare i32 @f_i32_half_bfloat_float_double(half, bfloat, float, double)


### PR DESCRIPTION
In some instances, an LLVM void type is used to model LLVM IR functions with no return type. This is inconsistent with MLIR APIs, which expects a function with no return value to have an empty return type. Handle this special case in `LLVMFuncOp` to avoid mismatches between the number of return values and return types between caller and callee.